### PR TITLE
Bug Fixes

### DIFF
--- a/AFB.ahk
+++ b/AFB.ahk
@@ -86,7 +86,7 @@ Reconnect(winWidth, winHeight) {
 	try {
 		for (searchImage in RECONNECT_IMG_SEARCH_ARRAY) {
 			if (ImageSearch(&foundX, &foundY, 0, 0, winWidth, winHeight, searchImage)) {
-				MouseMove(foundX - 20, FoundY - 20, 0)
+				MouseMove(foundX - 100, FoundY - 100, 0)
 				ClickImageMidPoint(searchImage, foundX, foundY)
 				return 1
 			}
@@ -128,8 +128,9 @@ ClickImageMidPoint(imageFile, xOffset, yOffset){
 	clickX 				:= imageMidPoint[1] + xOffset
 	clickY 				:= imageMidPoint[2] + yOffset
 
-	MouseMove(clickX, clickY, 25)
-	Sleep(250)
+	SendMode("Event")
+	MouseMove(clickX, clickY, 10)
+	SendMode("Input")
 	Click(clickX, clickY)
 }
 

--- a/AFB.ahk
+++ b/AFB.ahk
@@ -86,6 +86,7 @@ Reconnect(winWidth, winHeight) {
 	try {
 		for (searchImage in RECONNECT_IMG_SEARCH_ARRAY) {
 			if (ImageSearch(&foundX, &foundY, 0, 0, winWidth, winHeight, searchImage)) {
+				MouseMove(foundX - 20, FoundY - 20, 0)
 				ClickImageMidPoint(searchImage, foundX, foundY)
 				return 1
 			}
@@ -127,9 +128,8 @@ ClickImageMidPoint(imageFile, xOffset, yOffset){
 	clickX 				:= imageMidPoint[1] + xOffset
 	clickY 				:= imageMidPoint[2] + yOffset
 
-	; ! Clicks seems to be flakey, this is why using two Click() instead of the 3rd parameter
-	Click(clickX, clickY)
-	Sleep(350)
+	MouseMove(clickX, clickY, 25)
+	Sleep(250)
 	Click(clickX, clickY)
 }
 

--- a/AFB.ahk
+++ b/AFB.ahk
@@ -1,6 +1,6 @@
 ; AHK v2
 #SingleInstance Force
-#SetTitleMatchMode 3
+SetTitleMatchMode 3
 
 /*
 	constants

--- a/AFB.ahk
+++ b/AFB.ahk
@@ -1,5 +1,6 @@
 ; AHK v2
 #SingleInstance Force
+#SetTitleMatchMode 3
 
 /*
 	constants

--- a/AFB.ahk
+++ b/AFB.ahk
@@ -86,7 +86,6 @@ Reconnect(winWidth, winHeight) {
 	try {
 		for (searchImage in RECONNECT_IMG_SEARCH_ARRAY) {
 			if (ImageSearch(&foundX, &foundY, 0, 0, winWidth, winHeight, searchImage)) {
-				MouseMove(foundX - 100, FoundY - 100, 0)
 				ClickImageMidPoint(searchImage, foundX, foundY)
 				return 1
 			}
@@ -128,6 +127,15 @@ ClickImageMidPoint(imageFile, xOffset, yOffset){
 	clickX 				:= imageMidPoint[1] + xOffset
 	clickY 				:= imageMidPoint[2] + yOffset
 
+	/*
+		Teleports Mouse to the corner of the button, offset -100pxs to get further away from the button.
+		Then setting SendMode to Event allows us to "Side" the mouse onto the Reconnect button, therefore creating a hover event.
+		Then resetting the SendMode and in the end, clicking the button. 
+
+		The reason we "Slide" onto the Reconnect Button is because Roblox refuses to detect a MouseClick if the Mouse snapped onto the button.
+		This code here fixes https://github.com/UpDownLeftDie/AwayFromBlox/issues/16
+	*/
+	MouseMove(xOffset - 100, yOffset - 100, 0)
 	SendMode("Event")
 	MouseMove(clickX, clickY, 10)
 	SendMode("Input")


### PR DESCRIPTION
- Change Title Match Mode to 3 which is an exact match. (Closes #21)
- Fix reconnect click bug. (Closes #16)
  - Mouse snaps to imageCornerX - 20 and imageCornerY - 20 and then slides onto the middle of the button, creating hover event.